### PR TITLE
Define matplotlib backend to avoid crash

### DIFF
--- a/graphical_reports/views.py
+++ b/graphical_reports/views.py
@@ -24,6 +24,7 @@ from event_tracker.models import Task, AttackTactic, AttackSubTechnique, AttackT
 from event_tracker.views import MitreEventListView
 from event_tracker.views_credentials import badness_colormap, intensity_colormap
 
+matplotlib.use('agg')
 
 class GraphicalMitreEventTimelineView(PermissionRequiredMixin, View):
     permission_required = 'event_tracker.view_event'


### PR DESCRIPTION
This commit solves [Issue #2]( https://github.com/nccgroup/SteppingStones/issues/2)

Matplotlib does not recommend using `pyplot` in a web server environment, instead they recommend using the `Figure` interface. `pyplot` causes a memory leak in the current context. 

https://matplotlib.org/stable/gallery/user_interfaces/canvasagg.html
> It is not necessary to avoid using the pyplot interface in order to create figures without a graphical front-end - simply setting the backend to "Agg" would be sufficient.